### PR TITLE
Updating asset location to be relative to (_src/js).

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "main": "main.js",
   "scripts": {
     "start": "npm run watch:js",
-    "build:js": "webpack --config ./webpack.config.js --output-path ../assets/js",
-    "watch:js": "webpack -d --watch --config ./webpack.config.js --output-path ../assets/js",
+    "build:js": "webpack --config ./webpack.config.js --output-path ../../assets/js",
+    "watch:js": "webpack -d --watch --config ./webpack.config.js --output-path ../../assets/js",
     "analyze": "webpack --config ./webpack.config.js --json | webpack-bundle-size-analyzer"
   },
   "author": "40Digits Developers <developers@40digits.com>",


### PR DESCRIPTION
Setting relative to the assumed current directory (/_src/js) so that the output should send the file to (/assets/js) instead of (/_src/assets/js)